### PR TITLE
Make it easier to trouble-shoot a failure to connect to bitbucket

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -142,7 +142,14 @@ issue_counts = 0
 issues = []
 while True:
     url = "https://api.bitbucket.org/1.0/repositories/%s/%s/issues/?start=%d" % (options.bitbucket_username, options.bitbucket_repo, options.start-1) #-1 because the start option is id-1
-    response = urllib2.urlopen(url)
+    try:
+        response = urllib2.urlopen(url)
+    except urllib2.HTTPError as ex:
+        raise ValueError(
+            'Problem trying to connect to bitbucket ({url}): {ex} '
+            'Hint: the bitbucket repository name is case-sensitive.'
+            .format(url=url, ex=ex))
+
     result = json.loads(response.read())
     if not result['issues']:
         # Check to see if there is issues to process if not break out.


### PR DESCRIPTION
Unlike on Github, the repository name on Bitbucket is case sensitive. This
gotcha is a bit counter-intuitive and therefore can lead to some head-scratching
as to why the migration script is failing. Improving the exception message makes
it easier to figure out what is going wrong.
