### PR TITLE
[Proof-of-concept] Batch migration.

### DIFF
--- a/_schema.py
+++ b/_schema.py
@@ -1,0 +1,54 @@
+from axiom import item, attributes
+
+
+class MigrationInfo(item.Item):
+    signature = attributes.text(allowNone=False)
+
+
+class Issue(item.Item):
+    bitbucket_id = attributes.integer(allowNone=False)
+    github_id = attributes.integer(allowNone=True, default=None)
+    migrated = attributes.boolean(allowNone=False, default=False)
+    in_progress = attributes.boolean(allowNone=False, default=False)
+
+    title = attributes.text(allowNone=False)
+    body = attributes.text(allowNone=False)
+    closed = attributes.boolean(allowNone=False)
+    created_at = attributes.text(allowNone=False)
+    labels = attributes.textlist(allowNone=False)
+
+    original_issue = attributes.inmemory()
+
+    def json(self):
+        return {
+            u'issue': {
+                u'title': self.title,
+                u'body': self.body,
+                u'closed': self.closed,
+                u'created_at': self.created_at,
+                u'labels': self.labels,
+            },
+            u'comments': [
+                comment.json()
+                for comment
+                in self.store.query(Comment, Comment.issue == self)
+            ]
+        }
+
+
+class Comment(item.Item):
+    issue = attributes.reference(allowNone=False, reftype=Issue)
+
+    created_at = attributes.text(allowNone=False)
+    body = attributes.text(allowNone=False)
+
+    def json(self):
+        return {
+            u'created_at': self.created_at,
+            u'body': self.body,
+        }
+
+
+class User(item.Item):
+    user = attributes.text(allowNone=False)
+    name = attributes.text(allowNone=False)


### PR DESCRIPTION
So this is pretty much a PoC; it works (I successfully migrated our BB repo to GH with it), but since I ported the code to Python 2 and changed a whole bunch of stuff, I doubt you'll want to merge this as-is. It may prove useful to someone, though. (There may be some cases with public repos that aren't handled, since our repo is a private one)

Basically, it imports from a BitBucket issues export file (rather than the API), and keeps state in order to rewrite issue bodies to refer to the imported issue number, and recover from failures during the GitHub upload process. This also serves as a partial solution to #65, since you can just restart the migration: I didn't implement code to do this automatically, but sleeping for a little while and then checking if the issue that was supposed to be imported now exists would probably work.
