### PR TITLE
Fill gaps in bitbucket issue numbering

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -188,9 +188,12 @@ def main(options):
             status_url = push_respo.json()['url']
             gh_issue_url = verify_github_issue_import_finished(
                 status_url, options.gh_auth, headers).json()['issue_url']
-            # verify GH & BB issue IDs match
-            # if this fails, convert_links() will have incorrect output
-            # this will fail if the GH repository has pre-existing issues
+
+            # Verify GH & BB issue IDs match.
+            # If this assertion fails, convert_links() will have incorrect
+            # output.  This condition occurs when:
+            # - the GH repository has pre-existing issues.
+            # - the Bitbucket repository has gaps in the numbering.
             gh_issue_id = int(gh_issue_url.split('/')[-1])
             assert gh_issue_id == issue['local_id']
         print("Completed {} of {} issues".format(index + 1, len(issues)))

--- a/migrate.py
+++ b/migrate.py
@@ -223,6 +223,14 @@ def fill_gaps(issues, offset):
     >>> fill_gaps(issues, 0)
     >>> [issue['local_id'] for issue in issues]
     [1, 2, 3, 4, 5, 6, 7]
+
+    >>> issues = [
+    ...     dict(local_id=52),
+    ...     dict(local_id=54),
+    ... ]
+    >>> fill_gaps(issues, 50)
+    >>> [issue['local_id'] for issue in issues]
+    [51, 52, 53, 54]
     """
     start = offset + 1
     num = start

--- a/migrate.py
+++ b/migrate.py
@@ -199,6 +199,36 @@ def main(options):
         print("Completed {} of {} issues".format(index + 1, len(issues)))
 
 
+class DummyIssue(dict):
+    def __init__(self, num):
+        self.update(
+            local_id=num,
+            #...
+        )
+
+
+def fill_gaps(issues, offset):
+    """
+    Fill gaps in the issues, assuming an initial offset.
+
+    >>> issues = [
+    ...     dict(local_id=2),
+    ...     dict(local_id=4),
+    ... ]
+    >>> fill_gaps(issues, 0)
+    >>> [issue['local_id'] for issue in issues]
+    [1, 2, 3, 4]
+    """
+    start = offset + 1
+    num = start
+    index = num - start
+    while index < len(issues):
+        if issues[index]['local_id'] > num:
+            issues[index:index] = [DummyIssue(num)]
+        num += 1
+        index = num - start
+
+
 def get_issues(bb_url, start, bb_auth):
     """Fetch the issues from Bitbucket."""
     issues = []

--- a/migrate.py
+++ b/migrate.py
@@ -218,10 +218,11 @@ def fill_gaps(issues, offset):
     >>> issues = [
     ...     dict(local_id=2),
     ...     dict(local_id=4),
+    ...     dict(local_id=7),
     ... ]
     >>> fill_gaps(issues, 0)
     >>> [issue['local_id'] for issue in issues]
-    [1, 2, 3, 4]
+    [1, 2, 3, 4, 5, 6, 7]
     """
     start = offset + 1
     num = start


### PR DESCRIPTION
This series of patches adds support for filling gaps in issues, providing a workaround for #42.
