### PR TITLE
Ensure new labels do not contain commas

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -306,7 +306,9 @@ def convert_issue(issue, options, gh_milestones):
     labels = [issue['priority']]
     for k, v in issue['metadata'].items():
         if k in ['component', 'kind', 'version'] and v is not None:
-            labels.append(v)
+            # Commas are permitted in Bitbucket's components & versions, but 
+            # they cannot be in GitHub labels, so they must be removed.
+            labels.append(v.replace(',', ''))
 
     out = {
         'title': issue['title'],


### PR DESCRIPTION
Ran into an issue importing from a Bitbucket repo that had several components that included commas.  GitHub does not allow commas in labels, so converting those components into GitHub labels failed and caused the script to stop.