### PR TITLE
Allow overriding of username and cache user lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ It's probably easiest to install the dependencies using Python 3's built-in
     optional arguments:
       -h, --help            show this help message and exit
 
-      -bu BITBUCKET_USERNAME, --bb_user BITBUCKET_USERNAME
+      -bu BITBUCKET_USERNAME, --bb-user BITBUCKET_USERNAME
                             Your Bitbucket username. This is only necessary when
                             migrating private Bitbucket repositories.
 
-      -n, --dry_run         Perform a dry run and print everything.
+      -n, --dry-run         Perform a dry run and print everything.
 
       -f SKIP, --skip SKIP  The number of Bitbucket issues to skip. Note that if
                             Bitbucket issues were deleted, they are already

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It's probably easiest to install the dependencies using Python 3's built-in
 ## Parameters:
 
     $ python3 migrate.py -h
-    usage: migrate.py [-h] [-bu BITBUCKET_USERNAME] [-n] [-f START]
+    usage: migrate.py [-h] [-bu BITBUCKET_USERNAME] [-n] [-f SKIP] [-m _MAP_USERS]
                       bitbucket_repo github_repo github_username
 
     A tool to migrate issues from Bitbucket to GitHub.
@@ -51,6 +51,10 @@ It's probably easiest to install the dependencies using Python 3's built-in
       -f SKIP, --skip SKIP  The number of Bitbucket issues to skip. Note that if
                             Bitbucket issues were deleted, they are already
                             automatically skipped.
+      -m _MAP_USERS, --map-user _MAP_USERS
+                            Override user mapping for usernames, for example
+                            `--map-user fk=fkrull`. Can be specified multiple
+                            times.
 
     $ python3 migrate.py <bitbucket_repo> <github_repo> <github_username>
 

--- a/migrate.py
+++ b/migrate.py
@@ -68,7 +68,7 @@ def read_arguments():
     )
 
     parser.add_argument(
-        "-bu", "--bb_user", dest="bitbucket_username",
+        "-bu", "--bb-user", dest="bitbucket_username",
         help=(
             "Your Bitbucket username. This is only necessary when migrating "
             "private Bitbucket repositories."
@@ -76,7 +76,7 @@ def read_arguments():
     )
 
     parser.add_argument(
-        "-n", "--dry_run", action="store_true", dest="dry_run", default=False,
+        "-n", "--dry-run", action="store_true",
         help="Perform a dry run and print everything."
     )
 
@@ -109,7 +109,7 @@ def main(options):
                 """
                 Trying to access a private Bitbucket repository, but no
                 Bitbucket username was entered. Please rerun the script using
-                the argument `--bb_user <username>` to pass in your Bitbucket
+                the argument `--bb-user <username>` to pass in your Bitbucket
                 username.
                 """
             )

--- a/migrate.py
+++ b/migrate.py
@@ -359,6 +359,7 @@ def format_issue_body(issue, options):
     content = convert_changesets(issue['content'])
     content = convert_creole_braces(content)
     content = convert_links(content, options)
+    content = convert_users(content, options)
     return """Originally reported by: **{reporter}**
 
 {sep}
@@ -381,6 +382,7 @@ def format_comment_body(comment, options):
     content = convert_changesets(comment['content'])
     content = convert_creole_braces(content)
     content = convert_links(content, options)
+    content = convert_users(content, options)
     return """*Original comment by* **{author}**:
 
 {sep}
@@ -505,6 +507,20 @@ def convert_links(content, options):
     pattern = r'https://bitbucket.org/{repo}/issue/(\d+)'.format(
         repo=options.bitbucket_repo)
     return re.sub(pattern, r'#\1', content)
+
+
+MENTION_RE = re.compile(r'(?:^|(?<=[^\w]))@[a-zA-Z0-9_-]+\b')
+
+
+def convert_users(content, options):
+    """
+    Replace @mentions with users specified on the cli.
+    """
+    def replace_user(match):
+        matched = match.group()[1:]
+        return '@' + options.users.get(matched, matched)
+
+    return MENTION_RE.sub(replace_user, content)
 
 
 class GithubMilestones:


### PR DESCRIPTION
I used this successfully to migrate the issues for [deadsnakes](https://github.com/deadsnakes)

For example: https://github.com/deadsnakes/issues/issues?q=is%3Aissue+is%3Aclosed

You can see the invocation I used here: https://github.com/deadsnakes/issues/issues/5

Note: I also added `-` aliases for existing `_` cli options -- the general standard on linux is to use dashed arguments.