### PR TITLE
--skip-attribution-for to prevent "Originally by" about yourself.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ It's probably easiest to install the dependencies using Python 3's built-in
                             `--map-user fk=fkrull`. Can be specified multiple
                             times.
 
+      --skip-attribution-for BB_SKIP
+                            BitBucket user who doesn't need comments re-
+                            attributed. Useful to skip your own comments, because
+                            you are running this script, and the GitHub comments
+                            will be already under your name.
+
     $ python3 migrate.py <bitbucket_repo> <github_repo> <github_username>
 
 ## Example:

--- a/migrate.py
+++ b/migrate.py
@@ -368,7 +368,7 @@ def format_issue_body(issue, options):
     content = convert_creole_braces(content)
     content = convert_links(content, options)
     content = convert_users(content, options)
-    return """Originally reported by: **{reporter}**
+    return """*Originally reported by* **{reporter}**
 
 {sep}
 
@@ -391,7 +391,7 @@ def format_comment_body(comment, options):
     content = convert_creole_braces(content)
     content = convert_links(content, options)
     content = convert_users(content, options)
-    return """*Original comment by* **{author}**:
+    return """*Original comment by* **{author}**
 
 {sep}
 


### PR DESCRIPTION
I'm a frequent commenter in my repos.  When I migrate the issues to GitHub, all of the actions appear to come from me (since I ran the script).  Then many of the comments also say, "Originally by: bitbucket ned, GitHub nedbat" which seems unnecessary since the comment is already written by me.

Specifying `--me ned` indicates that anything authored by the Bitbucket user "ned" doesn't need the "Originally by:" indicator, which reduces noise.  If you liked the original behavior, just don't specify the switch.

Along the way, this refactored how the body of issues and comments are formatted.

(Note: this includes pull request #100 also)