### PR TITLE
Import version from 'name' field.

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -428,7 +428,7 @@ def convert_issue(
     for key in ['component', 'kind', 'version']:
         v = issue[key]
         if v is not None:
-            if key == 'component':
+            if key == 'component' or key == 'version':
                 v = v['name']
             # Commas are permitted in Bitbucket's components & versions, but
             # they cannot be in GitHub labels, so they must be removed.


### PR DESCRIPTION
Hi! We used this script recently to help migrate several packages, thanks so much for producing/maintaining it. While migrating issues, we had a bug when issues reported a `version`.

Similarly to the `component` field, the `version` field is a dictionary and the value is in `v['name']`. There is also another key with metadata linking to a page for that version (I ignored it since it wasn't relevant).

This PR fixed the issue for us. Cheers!