### PR TITLE
Update README for Python 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ dependency if you want to pull login credentials from the system keyring.
 It's probably easiest to install the dependencies using Python 3's built-in
 `venv` tool:
 
-    $ pyvenv ./py3
+    $ python3 -m venv ./py3
     $ source ./py3/bin/activate
     $ pip3 install -r requirements.pip
+    
+On Windows, use `.\py3\Scripts\activate.bat` instead of `source ./py3/bin/activate`
 
 ## Parameters:
 


### PR DESCRIPTION
`pyvenv` didn't work for me, so I checked [the Python docs](https://docs.python.org/3/library/venv.html) and saw this:

> Note: The pyvenv script has been deprecated as of Python 3.6 in favor of using python3 -m venv to help prevent any potential confusion as to which Python interpreter a virtual environment will be based on. 

Also added a small note about Windows, where you need to use `py3/Scripts/activate.bat` instead of `py3/bin/activate`