### PR TITLE
A self-contained install of bitbucket-issue-migration as a Docker executable container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:testing
+
+# Install dependencies
+RUN \
+  apt-get update && \
+  apt-get install --no-install-recommends -y git python3-pip python3-setuptools python3-wheel && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install bitbucket-issue-migration
+# keyring is not currently specified in requirements.pip since it's optional
+RUN \
+  pip3 install keyring && \
+  git clone https://github.com/jeffwidman/bitbucket-issue-migration.git && \
+  cd bitbucket-issue-migration && \
+  pip3 install -r requirements.pip
+
+# Configure entrypoint for executable container
+ENTRYPOINT ["python3", "bitbucket-issue-migration/migrate.py"]
+CMD ["-h"]


### PR DESCRIPTION
This way (Docker) users don't need to fiddle with pip/easy_install/etc, they can just build and run this container. If you're on Docker Hub the image could also be pre-built, so users would just need to run:

```shell
$ docker run -it jeffwidman/bitbucket-issue-migration ...
```

Otherwise, a local build would look like:

```shell
# ... checkout and cd into the repo
$ docker build -t bitbucket-issue-migration .
$ docker run -it bitbucket-issue-migration ...
```