### PR TITLE
Fix trailing comma when no GitHub user is found

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ On Windows, use `.\py3\Scripts\activate.bat` instead of `source ./py3/bin/activa
 
     $ python3 migrate.py -h
     usage: migrate.py [-h] [-bu BITBUCKET_USERNAME] [-n] [-f SKIP] [-m _MAP_USERS]
+                      [--skip-attribution-for BB_SKIP] [--link-changesets]
+                      [--mention-attachments] [--mention-changes]
                       bitbucket_repo github_repo github_username
 
     A tool to migrate issues from Bitbucket to GitHub.
@@ -59,15 +61,20 @@ On Windows, use `.\py3\Scripts\activate.bat` instead of `source ./py3/bin/activa
       -m _MAP_USERS, --map-user _MAP_USERS
                             Override user mapping for usernames, for example
                             `--map-user fk=fkrull`. Can be specified multiple
-                            times.
+                            times. Disable mapping for a user with an empty value,
+                            for example `--map-user fk=`.
 
       --skip-attribution-for BB_SKIP
-                            BitBucket user who doesn't need comments re-
-                            attributed. Useful to skip your own comments, because
-                            you are running this script, and the GitHub comments
-                            will be already under your name.
+                            Your BitBucket username, if you don't want comments
+                            re-attributed. Because you are running this script,
+                            the GitHub comments will already be under your name.
 
       --link-changesets     Link changeset references back to BitBucket.
+
+      --mention-attachments
+                            Mention the names of attachments.
+
+      --mention-changes     Mention changes in status as comments.
 
     $ python3 migrate.py <bitbucket_repo> <github_repo> <github_username>
 

--- a/migrate.py
+++ b/migrate.py
@@ -96,16 +96,18 @@ def read_arguments():
         "-m", "--map-user", action="append", dest="_map_users", default=[],
         help=(
             "Override user mapping for usernames, for example "
-            "`--map-user fk=fkrull`.  Can be specified multiple times."
+            "`--map-user fk=fkrull`. Can be specified multiple times. "
+            "Disable mapping for a user with an empty value, for example "
+            "`--map-user fk=`."
         ),
     )
 
     parser.add_argument(
         "--skip-attribution-for", dest="bb_skip",
         help=(
-            "BitBucket user who doesn't need comments re-attributed. Useful "
-            "to skip your own comments, because you are running this script, "
-            "and the GitHub comments will be already under your name."
+            "Your BitBucket username, if you don't want comments re-attributed. "
+            "Because you are running this script, the GitHub comments will "
+            "already be under your name."
         ),
     )
 
@@ -613,7 +615,9 @@ def format_change_body(change, options):
 
 def _gh_username(username, users, gh_auth):
     try:
-        return users[username]
+        user = users[username]
+        return user if user else None  # No GH account for this user
+
     except KeyError:
         pass
 
@@ -658,10 +662,10 @@ def format_user(user, options):
     bb_user = "Bitbucket: [{0}](https://bitbucket.org/{0})".format(user['nickname'])
     gh_username = _gh_username(user['nickname'], options.users, options.gh_auth)
     if gh_username is not None:
-        gh_user = "GitHub: [{0}](https://github.com/{0})".format(gh_username)
+        gh_user = ", GitHub: [{0}](https://github.com/{0})".format(gh_username)
     else:
         gh_user = ""
-    return (user['display_name'] + " (" + bb_user + ", " + gh_user + ")")
+    return "{0} ({1}{2})".format(user['display_name'], bb_user, gh_user)
 
 
 def convert_date(bb_date):


### PR DESCRIPTION
Also:

* Support disabling mapping to a GitHub user on the command line, for incorrectly-mapped BB users without a known GH account.
* Clarify help text of --skip-attribution-for
* Update help text in README with some recently added flags