### PR TITLE
Fix No such file or directory: '' error

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -22,7 +22,7 @@ import re
 import sys
 import time
 import warnings
-import os
+
 import getpass
 import requests
 

--- a/migrate.py
+++ b/migrate.py
@@ -22,7 +22,7 @@ import re
 import sys
 import time
 import warnings
-
+import os
 import getpass
 import requests
 
@@ -139,7 +139,12 @@ def main(options):
         repo=options.bitbucket_repo)
     options.bb_auth = None
     # Reads from a file that contains users' bitbucket-github username mapping
-    users_bb_gh_mapping = [line.rstrip() for line in open(''.join(options._map_users), "r")]
+    bb_gh_path = ''.join(options._map_users)
+    if bb_gh_path != '':
+        users_bb_gh_mapping = [line.rstrip() for line in open(bb_gh_path, "r")]
+    else:
+        users_bb_gh_mapping = []
+
     options.users = dict(user.split('=') for user in users_bb_gh_mapping)
     explicitly_mapped_users = dict(options.users)
     bb_repo_status = requests.head(bb_url).status_code


### PR DESCRIPTION
#138

I also encountered the same issue.

My current computer is following envrionment.
Machine: M1 Macbook Air
OS: macOS Monterey 12.6
Python: 3.10.6

```
$ python migrate.py -bu katsusuke "my-organization/my-repo" "my-organization/myrepo" katsusuke
Traceback (most recent call last):
  File "/Users/katsusuke/git/github.com/jeffwidman/bitbucket-issue-migration/migrate.py", line 897, in <module>
    sys.exit(main(options))
  File "/Users/katsusuke/git/github.com/jeffwidman/bitbucket-issue-migration/migrate.py", line 142, in main
    users_bb_gh_mapping = [line.rstrip() for line in open(''.join(options._map_users), "r")]
FileNotFoundError: [Errno 2] No such file or directory: ''
```

```
python --version
Python 3.10.6
```

I think `open('')` throws FileNotFoundError.

```
$ python
Python 3.10.6 (main, Aug 24 2022, 13:55:36) [Clang 13.1.6 (clang-1316.0.21.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> open("")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
FileNotFoundError: [Errno 2] No such file or directory: ''
```

I tried it on Linux, but open function have the same behavior.

```
$ uname -a
uname -a
Linux ip-10-0-10-74 5.13.0-1022-aws #24~20.04.1-Ubuntu SMP Thu Apr 7 22:10:15 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04.3 LTS"
$ python3
Python 3.8.10 (default, Mar 15 2022, 12:22:08)
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> open('')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
FileNotFoundError: [Errno 2] No such file or directory: ''
```
